### PR TITLE
Ignore duplicate dfns created by rdf12-concepts

### DIFF
--- a/data/link-defaults.infotree
+++ b/data/link-defaults.infotree
@@ -75,6 +75,10 @@ info: ignored-specs
 	spec: ecmascript; replacedBy: webidl
 	spec: css-style-attr; replacedBy: dom
 	spec: rdf11-mt; spec: rdf11-concepts; replacedBy: dom
+	spec: rdf12-concepts;
+		replacedBy: css2
+		replacedBy: dom
+		replacedBy: infra
 	spec: epub-33; replacedBy: html
 	spec: css-2d-transforms-1
 	spec: css-3d-transforms-1


### PR DESCRIPTION
RDF specs are starting to use cross-referencing more systematically and exporting new terms as a result. Problem is that `rdf12-concepts` defines core terms that are also defined in other core specs (`css2`, `dom`, and `infra`). Bikeshed complains about terms such as "string" being ambiguous as a result.

This update makes Bikeshed favor the latter specs by default for backwards compatibility.

Via https://github.com/w3c/webref/issues/1619